### PR TITLE
Stage 2 — Streaks v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "just-5",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "index.ts",
   "scripts": {
     "start": "expo start",

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,8 @@
 import * as SQLite from 'expo-sqlite';
 
 const DB_NAME = 'just5.db';
+const MAX_GRACES = 3;
+const GRACE_EARN_INTERVAL = 7;
 
 let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
 
@@ -24,10 +26,47 @@ export function getDb(): Promise<SQLite.SQLiteDatabase> {
         INSERT OR IGNORE INTO streak_state (id, current_daily, last_started_date)
           VALUES (1, 0, NULL);
       `);
+      await migrateStreakState(db);
       return db;
     });
   }
   return dbPromise;
+}
+
+async function migrateStreakState(db: SQLite.SQLiteDatabase): Promise<void> {
+  const cols = await db.getAllAsync<{ name: string }>('PRAGMA table_info(streak_state)');
+  const has = (n: string) => cols.some((c) => c.name === n);
+
+  if (!has('best_daily')) {
+    await db.execAsync('ALTER TABLE streak_state ADD COLUMN best_daily INTEGER NOT NULL DEFAULT 0');
+  }
+  if (!has('current_conversion')) {
+    await db.execAsync(
+      'ALTER TABLE streak_state ADD COLUMN current_conversion INTEGER NOT NULL DEFAULT 0',
+    );
+  }
+  if (!has('best_conversion')) {
+    await db.execAsync(
+      'ALTER TABLE streak_state ADD COLUMN best_conversion INTEGER NOT NULL DEFAULT 0',
+    );
+  }
+  if (!has('last_converted_date')) {
+    await db.execAsync('ALTER TABLE streak_state ADD COLUMN last_converted_date TEXT');
+  }
+  if (!has('graces_available')) {
+    await db.execAsync(
+      'ALTER TABLE streak_state ADD COLUMN graces_available INTEGER NOT NULL DEFAULT 0',
+    );
+  }
+  if (!has('graces_earned_at_streak')) {
+    await db.execAsync(
+      'ALTER TABLE streak_state ADD COLUMN graces_earned_at_streak INTEGER NOT NULL DEFAULT 0',
+    );
+  }
+
+  await db.runAsync(
+    'UPDATE streak_state SET best_daily = current_daily WHERE best_daily < current_daily',
+  );
 }
 
 export type SessionRow = {
@@ -38,15 +77,25 @@ export type SessionRow = {
   converted: number;
 };
 
-export type StreakState = {
+export type StreakStateRow = {
   current_daily: number;
+  best_daily: number;
   last_started_date: string | null;
+  current_conversion: number;
+  best_conversion: number;
+  last_converted_date: string | null;
+  graces_available: number;
+  graces_earned_at_streak: number;
 };
 
 export type HomeStats = {
   totalSessions: number;
   totalFocusSeconds: number;
   currentDailyStreak: number;
+  bestDailyStreak: number;
+  currentConversionStreak: number;
+  bestConversionStreak: number;
+  gracesAvailable: number;
 };
 
 function toLocalDateKey(timestampMs: number): string {
@@ -65,6 +114,98 @@ function dayDiffInDays(a: string, b: string): number {
   return Math.round((bMs - aMs) / (1000 * 60 * 60 * 24));
 }
 
+async function readStreakState(db: SQLite.SQLiteDatabase): Promise<StreakStateRow> {
+  const row = await db.getFirstAsync<StreakStateRow>(
+    `SELECT current_daily, best_daily, last_started_date,
+            current_conversion, best_conversion, last_converted_date,
+            graces_available, graces_earned_at_streak
+     FROM streak_state WHERE id = 1`,
+  );
+  return (
+    row ?? {
+      current_daily: 0,
+      best_daily: 0,
+      last_started_date: null,
+      current_conversion: 0,
+      best_conversion: 0,
+      last_converted_date: null,
+      graces_available: 0,
+      graces_earned_at_streak: 0,
+    }
+  );
+}
+
+function applyDailyOnSave(
+  prev: StreakStateRow,
+  todayKey: string,
+): { current: number; graces: number; gracesEarnedAt: number } {
+  if (!prev.last_started_date) {
+    return { current: 1, graces: prev.graces_available, gracesEarnedAt: 0 };
+  }
+  if (prev.last_started_date === todayKey) {
+    return {
+      current: prev.current_daily,
+      graces: prev.graces_available,
+      gracesEarnedAt: prev.graces_earned_at_streak,
+    };
+  }
+  const diff = dayDiffInDays(prev.last_started_date, todayKey);
+  if (diff === 1) {
+    return {
+      current: prev.current_daily + 1,
+      graces: prev.graces_available,
+      gracesEarnedAt: prev.graces_earned_at_streak,
+    };
+  }
+  if (diff > 1) {
+    const missed = diff - 1;
+    if (prev.graces_available >= missed) {
+      return {
+        current: prev.current_daily + 1,
+        graces: prev.graces_available - missed,
+        gracesEarnedAt: prev.graces_earned_at_streak,
+      };
+    }
+  }
+  return { current: 1, graces: prev.graces_available, gracesEarnedAt: 0 };
+}
+
+function applyConversionOnSave(
+  prev: StreakStateRow,
+  todayKey: string,
+  converted: boolean,
+): { current: number; lastDate: string | null } {
+  if (!converted) {
+    return { current: prev.current_conversion, lastDate: prev.last_converted_date };
+  }
+  if (!prev.last_converted_date) {
+    return { current: 1, lastDate: todayKey };
+  }
+  if (prev.last_converted_date === todayKey) {
+    return { current: prev.current_conversion, lastDate: todayKey };
+  }
+  const diff = dayDiffInDays(prev.last_converted_date, todayKey);
+  if (diff === 1) {
+    return { current: prev.current_conversion + 1, lastDate: todayKey };
+  }
+  return { current: 1, lastDate: todayKey };
+}
+
+function maybeEarnGrace(
+  newDailyStreak: number,
+  gracesAvailable: number,
+  gracesEarnedAtStreak: number,
+): { graces: number; earnedAt: number } {
+  const milestone = Math.floor(newDailyStreak / GRACE_EARN_INTERVAL) * GRACE_EARN_INTERVAL;
+  if (milestone > gracesEarnedAtStreak) {
+    return {
+      graces: Math.min(MAX_GRACES, gracesAvailable + 1),
+      earnedAt: milestone,
+    };
+  }
+  return { graces: gracesAvailable, earnedAt: gracesEarnedAtStreak };
+}
+
 export async function recordSession(params: {
   startedAt: number;
   endedAt: number;
@@ -81,24 +222,29 @@ export async function recordSession(params: {
   );
 
   const todayKey = toLocalDateKey(params.startedAt);
-  const state = await db.getFirstAsync<StreakState>(
-    'SELECT current_daily, last_started_date FROM streak_state WHERE id = 1',
-  );
+  const prev = await readStreakState(db);
 
-  let nextStreak = 1;
-  if (state?.last_started_date) {
-    if (state.last_started_date === todayKey) {
-      nextStreak = state.current_daily;
-    } else {
-      const diff = dayDiffInDays(state.last_started_date, todayKey);
-      nextStreak = diff === 1 ? state.current_daily + 1 : 1;
-    }
-  }
+  const daily = applyDailyOnSave(prev, todayKey);
+  const conv = applyConversionOnSave(prev, todayKey, params.converted);
+  const grace = maybeEarnGrace(daily.current, daily.graces, daily.gracesEarnedAt);
+
+  const nextBestDaily = Math.max(prev.best_daily, daily.current);
+  const nextBestConversion = Math.max(prev.best_conversion, conv.current);
 
   await db.runAsync(
-    'UPDATE streak_state SET current_daily = ?, last_started_date = ? WHERE id = 1',
-    nextStreak,
+    `UPDATE streak_state SET
+       current_daily = ?, best_daily = ?, last_started_date = ?,
+       current_conversion = ?, best_conversion = ?, last_converted_date = ?,
+       graces_available = ?, graces_earned_at_streak = ?
+     WHERE id = 1`,
+    daily.current,
+    nextBestDaily,
     todayKey,
+    conv.current,
+    nextBestConversion,
+    conv.lastDate,
+    grace.graces,
+    grace.earnedAt,
   );
 }
 
@@ -107,20 +253,33 @@ export async function loadHomeStats(): Promise<HomeStats> {
   const totals = await db.getFirstAsync<{ count: number; total: number | null }>(
     'SELECT COUNT(*) AS count, SUM(duration_seconds) AS total FROM sessions',
   );
-  const state = await db.getFirstAsync<StreakState>(
-    'SELECT current_daily, last_started_date FROM streak_state WHERE id = 1',
-  );
+  const state = await readStreakState(db);
+  const todayKey = toLocalDateKey(Date.now());
 
-  let currentDailyStreak = state?.current_daily ?? 0;
-  if (state?.last_started_date && currentDailyStreak > 0) {
-    const todayKey = toLocalDateKey(Date.now());
+  let currentDaily = state.current_daily;
+  if (state.last_started_date && currentDaily > 0) {
     const diff = dayDiffInDays(state.last_started_date, todayKey);
-    if (diff > 1) currentDailyStreak = 0;
+    if (diff > 1) {
+      const missed = diff - 1;
+      if (state.graces_available < missed) {
+        currentDaily = 0;
+      }
+    }
+  }
+
+  let currentConversion = state.current_conversion;
+  if (state.last_converted_date && currentConversion > 0) {
+    const diff = dayDiffInDays(state.last_converted_date, todayKey);
+    if (diff > 1) currentConversion = 0;
   }
 
   return {
     totalSessions: totals?.count ?? 0,
     totalFocusSeconds: totals?.total ?? 0,
-    currentDailyStreak,
+    currentDailyStreak: currentDaily,
+    bestDailyStreak: state.best_daily,
+    currentConversionStreak: currentConversion,
+    bestConversionStreak: state.best_conversion,
+    gracesAvailable: state.graces_available,
   };
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -176,7 +176,10 @@ function applyConversionOnSave(
   converted: boolean,
 ): { current: number; lastDate: string | null } {
   if (!converted) {
-    return { current: prev.current_conversion, lastDate: prev.last_converted_date };
+    if (prev.last_converted_date === todayKey) {
+      return { current: prev.current_conversion, lastDate: prev.last_converted_date };
+    }
+    return { current: 0, lastDate: prev.last_converted_date };
   }
   if (!prev.last_converted_date) {
     return { current: 1, lastDate: todayKey };

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -32,13 +32,27 @@ export default function HomeScreen({ navigation }: Props) {
   return (
     <SafeAreaView style={styles.safe} edges={['top', 'bottom']}>
       <View style={styles.container}>
-        <View style={styles.header}>
-          <Text style={styles.streakLabel}>Streak</Text>
-          <Text style={styles.streakValue}>
-            {stats?.currentDailyStreak ?? 0}
-            <Text style={styles.streakUnit}> {stats?.currentDailyStreak === 1 ? 'day' : 'days'}</Text>
-          </Text>
+        <View style={styles.streaksHeader}>
+          <StreakBlock
+            label="Daily"
+            current={stats?.currentDailyStreak ?? 0}
+            best={stats?.bestDailyStreak ?? 0}
+          />
+          <View style={styles.streakDivider} />
+          <StreakBlock
+            label="Conversion"
+            current={stats?.currentConversionStreak ?? 0}
+            best={stats?.bestConversionStreak ?? 0}
+          />
         </View>
+
+        {(stats?.gracesAvailable ?? 0) > 0 && (
+          <View style={styles.gracesBadge}>
+            <Text style={styles.gracesText}>
+              {stats?.gracesAvailable} grace{stats?.gracesAvailable === 1 ? '' : 's'} saved
+            </Text>
+          </View>
+        )}
 
         <Pressable
           accessibilityRole="button"
@@ -60,6 +74,24 @@ export default function HomeScreen({ navigation }: Props) {
   );
 }
 
+function StreakBlock({
+  label,
+  current,
+  best,
+}: {
+  label: string;
+  current: number;
+  best: number;
+}) {
+  return (
+    <View style={styles.streakBlock}>
+      <Text style={styles.streakLabel}>{label}</Text>
+      <Text style={styles.streakValue}>{current}</Text>
+      <Text style={styles.streakBest}>Best {best}</Text>
+    </View>
+  );
+}
+
 function Stat({ label, value }: { label: string; value: string }) {
   return (
     <View style={styles.stat}>
@@ -74,19 +106,39 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     paddingHorizontal: spacing.lg,
-    paddingTop: spacing.xl,
+    paddingTop: spacing.lg,
     paddingBottom: spacing.lg,
     justifyContent: 'space-between',
   },
-  header: { alignItems: 'center', gap: spacing.xs },
+  streaksHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-around',
+    backgroundColor: colors.surface,
+    borderRadius: radii.md,
+    paddingVertical: spacing.md,
+  },
+  streakBlock: { alignItems: 'center', flex: 1, gap: 2 },
+  streakDivider: { width: 1, height: 56, backgroundColor: colors.border },
   streakLabel: {
     color: colors.textMuted,
-    fontSize: 14,
+    fontSize: 11,
     letterSpacing: 1.5,
     textTransform: 'uppercase',
   },
-  streakValue: { color: colors.text, fontSize: 56, fontWeight: '700' },
-  streakUnit: { color: colors.textMuted, fontSize: 20, fontWeight: '500' },
+  streakValue: { color: colors.text, fontSize: 40, fontWeight: '700' },
+  streakBest: { color: colors.textMuted, fontSize: 12 },
+  gracesBadge: {
+    alignSelf: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: radii.pill,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    marginTop: spacing.sm,
+  },
+  gracesText: { color: colors.success, fontSize: 12, letterSpacing: 0.5 },
   startButton: {
     alignSelf: 'center',
     width: 260,


### PR DESCRIPTION
Closes #2.

## Summary
- **Conversion streak** — only counts days with at least one `converted = true` session; resets on a non-converted day, holds on rest days that have conversions, doesn't increment on already-counted days.
- **Best vs current** — separate `best_daily` and `best_conversion` columns, monotonically increasing.
- **Grace period** — earn +1 grace each time the daily streak crosses a 7-day milestone (`graces_earned_at_streak` tracks the last awarded milestone so doubles can't happen). Cap at 3 stored. Missed days within the grace budget are absorbed; otherwise streak resets.
- **Migration** — `migrateStreakState` introspects `PRAGMA table_info` and `ALTER TABLE` adds new columns in-place. Existing v0.1.0 sessions and their daily streak survive untouched; `best_daily` is backfilled from `current_daily`.
- **UI** — Home now shows Daily and Conversion streaks side-by-side in a single surface, each with `Best N` underneath. A subtle "N grace(s) saved" badge appears only when graces > 0.

## Test plan
- [ ] Start the app on a v0.1.0 install — existing streak preserved, no crash on migration
- [ ] Complete a session and tap "I'm done" before 5 min trigger (or use cancel) — daily streak increments, conversion does not
- [ ] Complete a session and tap "Keep going" past 5:00 then "Done" — both daily and conversion increment
- [ ] On day 8 with a 7-day streak, miss day, then return on day 9 — streak survives, graces decremented
- [ ] Reach a 7-day daily streak — graces badge appears showing 1
- [ ] Reach a 14-day daily streak — graces shows 2