### PR TITLE
Stage 3 — Stats Screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,6 +4,7 @@ import { StatusBar } from 'expo-status-bar';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import HomeScreen from './src/screens/HomeScreen';
 import SessionEndScreen from './src/screens/SessionEndScreen';
+import StatsScreen from './src/screens/StatsScreen';
 import TimerScreen from './src/screens/TimerScreen';
 import { RootStackParamList } from './src/navigation/types';
 import { colors } from './src/theme';
@@ -44,6 +45,7 @@ export default function App() {
             component={SessionEndScreen}
             options={{ gestureEnabled: false }}
           />
+          <Stack.Screen name="Stats" component={StatsScreen} />
         </Stack.Navigator>
         <StatusBar style="light" />
       </NavigationContainer>

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Just 5",
     "slug": "just-5",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3255,6 +3255,654 @@
         "node": ">= 20.19.4"
       }
     },
+    "node_modules/@react-native/metro-babel-transformer": {
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.85.2.tgz",
+      "integrity": "sha512-lU9XOGahpHvQff30H5lnvh9RYbVwC1zpSHpl84E+7BD2zj0FvW+pD7MBh7CWbmbWmegjtAb+U/2bokXcDVA+jA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@react-native/babel-preset": "0.85.2",
+        "hermes-parser": "0.33.3",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/babel-plugin-codegen": {
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.85.2.tgz",
+      "integrity": "sha512-5Dqn08kRTUIxPLYju9hExI0cR1ESX+P5tEv5yv0q0UZcisRTw0VB8iUWDIph2LdY1i5Dc8PIvuaWMRNCw3vnKg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.29.0",
+        "@react-native/codegen": "0.85.2"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/babel-preset": {
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.85.2.tgz",
+      "integrity": "sha512-7d2yW23eKkVt0FbbnZLxqO7KybGLtQXOuvvcO1NUOYGtjzVh6ihNKn0TIHrhSNpMyHwYLDoiiuj95wLtcg3IwQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-proposal-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-transform-async-generator-functions": "^7.25.4",
+        "@babel/plugin-transform-async-to-generator": "^7.24.7",
+        "@babel/plugin-transform-block-scoping": "^7.25.0",
+        "@babel/plugin-transform-class-properties": "^7.25.4",
+        "@babel/plugin-transform-classes": "^7.25.4",
+        "@babel/plugin-transform-destructuring": "^7.24.8",
+        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
+        "@babel/plugin-transform-for-of": "^7.24.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+        "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
+        "@babel/plugin-transform-optional-chaining": "^7.24.8",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
+        "@babel/plugin-transform-react-display-name": "^7.24.7",
+        "@babel/plugin-transform-react-jsx": "^7.25.2",
+        "@babel/plugin-transform-react-jsx-self": "^7.24.7",
+        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
+        "@babel/plugin-transform-regenerator": "^7.24.7",
+        "@babel/plugin-transform-runtime": "^7.24.7",
+        "@babel/plugin-transform-typescript": "^7.25.2",
+        "@babel/plugin-transform-unicode-regex": "^7.24.7",
+        "@react-native/babel-plugin-codegen": "0.85.2",
+        "babel-plugin-syntax-hermes-parser": "0.33.3",
+        "babel-plugin-transform-flow-enums": "^0.0.2",
+        "react-refresh": "^0.14.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/codegen": {
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.85.2.tgz",
+      "integrity": "sha512-XCginmxh0//++EXVOEJHBVZxHla294FzLCFF6jXwAUjvXVhqyIKyxhABfz+r4OOmaiuWk4Rtd4arqdAzeHeprg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/parser": "^7.29.0",
+        "hermes-parser": "0.33.3",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "tinyglobby": "^0.2.15",
+        "yargs": "^17.6.2"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/babel-plugin-syntax-hermes-parser": {
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.33.3.tgz",
+      "integrity": "sha512-/Z9xYdaJ1lC0pT9do6TqCqhOSLfZ5Ot8D5za1p+feEfWYupCOfGbhhEXN9r2ZgJtDNUNRw/Z+T2CvAGKBqtqWA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "hermes-parser": "0.33.3"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/hermes-estree": {
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.33.3.tgz",
+      "integrity": "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/hermes-parser": {
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.33.3.tgz",
+      "integrity": "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "hermes-estree": "0.33.3"
+      }
+    },
+    "node_modules/@react-native/metro-config": {
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@react-native/metro-config/-/metro-config-0.85.2.tgz",
+      "integrity": "sha512-YkTIMfTPeyMUrtpQo/7zd3oybVYJCfTp8626PqoakOvEiWi9PxsUpZ8j44a5GFtOIq8Nc6WWVBiFRn/6qdi1uQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@react-native/js-polyfills": "0.85.2",
+        "@react-native/metro-babel-transformer": "0.85.2",
+        "metro-config": "^0.84.0",
+        "metro-runtime": "^0.84.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/@react-native/js-polyfills": {
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.85.2.tgz",
+      "integrity": "sha512-esGEAmKVM40DV/yVmNljCKZTIeUo7qXqc+Hwffkv3TG+b3E24xyFovHrbP98gGxZr2ZsEyx+2sKLdXF5asY5nw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@react-native/metro-config/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/hermes-estree": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@react-native/metro-config/node_modules/hermes-parser": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "hermes-estree": "0.35.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/metro": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.84.3.tgz",
+      "integrity": "sha512-1h3lbVrE6hGf1e/764HfhPGg/bGrWMJDDh7G2rc4gFYZboVuI40BlG/y+UhtbhQDNlO/csMvrcnK0YrTlHUVew==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "accepts": "^2.0.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^2.0.0",
+        "connect": "^3.6.5",
+        "debug": "^4.4.0",
+        "error-stack-parser": "^2.0.6",
+        "flow-enums-runtime": "^0.0.6",
+        "graceful-fs": "^4.2.4",
+        "hermes-parser": "0.35.0",
+        "image-size": "^1.0.2",
+        "invariant": "^2.2.4",
+        "jest-worker": "^29.7.0",
+        "jsc-safe-url": "^0.2.2",
+        "lodash.throttle": "^4.1.1",
+        "metro-babel-transformer": "0.84.3",
+        "metro-cache": "0.84.3",
+        "metro-cache-key": "0.84.3",
+        "metro-config": "0.84.3",
+        "metro-core": "0.84.3",
+        "metro-file-map": "0.84.3",
+        "metro-resolver": "0.84.3",
+        "metro-runtime": "0.84.3",
+        "metro-source-map": "0.84.3",
+        "metro-symbolicate": "0.84.3",
+        "metro-transform-plugins": "0.84.3",
+        "metro-transform-worker": "0.84.3",
+        "mime-types": "^3.0.1",
+        "nullthrows": "^1.1.1",
+        "serialize-error": "^2.1.0",
+        "source-map": "^0.5.6",
+        "throat": "^5.0.0",
+        "ws": "^7.5.10",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "metro": "src/cli.js"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/metro-babel-transformer": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.3.tgz",
+      "integrity": "sha512-svAA+yMLpeMiGcz/jKJs4oHpIGEx4nBqNEJ5AGj4CYIg1efvK+A0TjR6tgIuc6tKO5e8JmN/1lglpN2+f3/z/w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "flow-enums-runtime": "^0.0.6",
+        "hermes-parser": "0.35.0",
+        "metro-cache-key": "0.84.3",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/metro-cache": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.3.tgz",
+      "integrity": "sha512-0QElxwLaHqLZf+Xqio8QrjVbuXP/8sJfQBGSPiITlKDVXrVLefuzYVSH9Sj+QL6lrPj2gYZd/iwQh1yZuVKnLA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "exponential-backoff": "^3.1.1",
+        "flow-enums-runtime": "^0.0.6",
+        "https-proxy-agent": "^7.0.5",
+        "metro-core": "0.84.3"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/metro-cache-key": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.3.tgz",
+      "integrity": "sha512-TnSL1Fdvrw+2glTdBSRmA5TL8l/i16ECjsrUdf3E5HncA+sNx8KcwDG8r+3ct1UhfYcusJypzZqTN55FZZcwGg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/metro-config": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.3.tgz",
+      "integrity": "sha512-JmCzZWOETR+O22q8oPBWyQppx3roU9EbkbGzD8Gf1jukQ4b5T1fTzqqHruu6K4sTiNq5zVQySmKF6bp4kVARew==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "connect": "^3.6.5",
+        "flow-enums-runtime": "^0.0.6",
+        "jest-validate": "^29.7.0",
+        "metro": "0.84.3",
+        "metro-cache": "0.84.3",
+        "metro-core": "0.84.3",
+        "metro-runtime": "0.84.3",
+        "yaml": "^2.6.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/metro-core": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.3.tgz",
+      "integrity": "sha512-cc0pvAa80ai1nDmqqz0P59a+0ZqCZ/YHU/3jEekZL6spFnYDfX8iDLdn9FR6kX+67rmzKxHNrbrSRFLX2AYocw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "lodash.throttle": "^4.1.1",
+        "metro-resolver": "0.84.3"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/metro-file-map": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.3.tgz",
+      "integrity": "sha512-1cL4m4Jv1yRUt9RJExZQLfccscdlMNOcRG6LHLtmJhf3BG9j3MujPVc7CIpKYdFl+KUl+sdjge6oO3+meKCHQA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "fb-watchman": "^2.0.0",
+        "flow-enums-runtime": "^0.0.6",
+        "graceful-fs": "^4.2.4",
+        "invariant": "^2.2.4",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "nullthrows": "^1.1.1",
+        "walker": "^1.0.7"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/metro-minify-terser": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.3.tgz",
+      "integrity": "sha512-3ofrG2OQyJbO9RNhCfOcl8QU7EE2WrSsnN5dFkuZaJO5+4Imujr9bUXmspeNlXRsOVk0F/rVRbEFH98lFSCkBQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "terser": "^5.15.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/metro-resolver": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.3.tgz",
+      "integrity": "sha512-pjEzGDtoM8DTHAIPK/9u9ZxszEiuRohYUVImWvgbnB91V4gqYJpQcoEYUugf2NIm1lrX5HNu0OvNqWmPBnGYjA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/metro-runtime": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.3.tgz",
+      "integrity": "sha512-o7HLRfMyVk9N2dUZ9VjQfB6xxUItL9Pi9WcqxURE7MEKOH6wbGt9/E92YdYLluTOtkzYAEVfdC6h6lcxqA+hMQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/metro-source-map": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.3.tgz",
+      "integrity": "sha512-jS48CeSzw78M8y6VE0f9uy3lVmfbOS677j2VCxnlmlYmnahcXuC6IhoN9K6LynNvos9517yUadcfgioju38xYQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-symbolicate": "0.84.3",
+        "nullthrows": "^1.1.1",
+        "ob1": "0.84.3",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/metro-symbolicate": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.3.tgz",
+      "integrity": "sha512-J9Tpo8NCycYrozRvBIUyOwGAu4xkawOsAppmTscFiaegK0WvuDGwIM53GbzVSnytCHjVAF0io5GQxpkrKTuc7g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-source-map": "0.84.3",
+        "nullthrows": "^1.1.1",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "bin": {
+        "metro-symbolicate": "src/index.js"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/metro-transform-plugins": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.3.tgz",
+      "integrity": "sha512-8S3baq2XhBaafHEH5Q8sJW6tmzsEJk80qKc3RU/nZV1MsnYq94RdjTUR6AyKjQd6Rfsk1BtBxhtiNnk7mgslCg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/metro-transform-worker": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.3.tgz",
+      "integrity": "sha512-Wjba7PyYktNRsHbPmkx2J2UX32rAzcDXjCu49zPHeF/viJlYJhwRaNePQcHaCRqQ+kmgQT4ThprsnJfDj71ZMA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "flow-enums-runtime": "^0.0.6",
+        "metro": "0.84.3",
+        "metro-babel-transformer": "0.84.3",
+        "metro-cache": "0.84.3",
+        "metro-cache-key": "0.84.3",
+        "metro-minify-terser": "0.84.3",
+        "metro-source-map": "0.84.3",
+        "metro-transform-plugins": "0.84.3",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/ob1": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.3.tgz",
+      "integrity": "sha512-J7554Ef8bzmKaDY365Afq6PF+qtdnY/d5PKUQFrsKlZHV/N3OGZewVrvDrQDyX5V5NJjTpcAKtlrFZcDr+HvpQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-config/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@react-native/normalize-colors": {
       "version": "0.81.5",
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.81.5.tgz",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "just-5",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "index.ts",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "eslint . --ext .ts,.tsx",
+    "lint": "eslint .",
     "format": "prettier --write \"**/*.{ts,tsx,json,md}\"",
     "typecheck": "tsc --noEmit"
   },

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -1,0 +1,32 @@
+import { StyleSheet, Text, View } from 'react-native';
+import type { ContributionDay } from '../db';
+import { colors, radii, spacing } from '../theme';
+
+const CELL_COLORS: Record<ContributionDay['kind'], string> = {
+  none: colors.border,
+  started: '#3D5BCB',
+  converted: colors.success,
+};
+
+export function ContributionGraph({ days }: { days: ContributionDay[] }) {
+  return (
+    <View style={styles.row}>
+      {days.map((d) => (
+        <View key={d.dateKey} style={styles.col}>
+          <View
+            style={[styles.cell, { backgroundColor: CELL_COLORS[d.kind] }]}
+            accessibilityLabel={`${d.weekday}: ${d.kind}`}
+          />
+          <Text style={styles.label}>{d.weekday[0]}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: { flexDirection: 'row', justifyContent: 'space-between' },
+  col: { alignItems: 'center', gap: spacing.xs, flex: 1 },
+  cell: { width: '85%', aspectRatio: 1, borderRadius: radii.sm },
+  label: { color: colors.textMuted, fontSize: 11 },
+});

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -15,6 +15,8 @@ export function ContributionGraph({ days }: { days: ContributionDay[] }) {
         <View key={d.dateKey} style={styles.col}>
           <View
             style={[styles.cell, { backgroundColor: CELL_COLORS[d.kind] }]}
+            accessible
+            accessibilityRole="image"
             accessibilityLabel={`${d.weekday}: ${d.kind}`}
           />
           <Text style={styles.label}>{d.weekday[0]}</Text>

--- a/src/components/HourBars.tsx
+++ b/src/components/HourBars.tsx
@@ -1,0 +1,44 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, radii, spacing } from '../theme';
+
+export function HourBars({ counts }: { counts: number[] }) {
+  const max = Math.max(1, ...counts);
+  return (
+    <View>
+      <View style={styles.row}>
+        {counts.map((c, h) => (
+          <View key={h} style={styles.col}>
+            <View style={styles.barTrack}>
+              <View
+                style={[
+                  styles.barFill,
+                  { height: `${(c / max) * 100}%`, opacity: c === 0 ? 0.3 : 1 },
+                ]}
+              />
+            </View>
+          </View>
+        ))}
+      </View>
+      <View style={styles.axis}>
+        <Text style={styles.axisLabel}>12a</Text>
+        <Text style={styles.axisLabel}>6a</Text>
+        <Text style={styles.axisLabel}>12p</Text>
+        <Text style={styles.axisLabel}>6p</Text>
+        <Text style={styles.axisLabel}>11p</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: { flexDirection: 'row', alignItems: 'flex-end', height: 80, gap: 2 },
+  col: { flex: 1, height: '100%', justifyContent: 'flex-end' },
+  barTrack: { flex: 1, justifyContent: 'flex-end' },
+  barFill: { backgroundColor: colors.primary, borderRadius: radii.sm, minHeight: 2 },
+  axis: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: spacing.xs,
+  },
+  axisLabel: { color: colors.textMuted, fontSize: 10 },
+});

--- a/src/components/LengthHistogram.tsx
+++ b/src/components/LengthHistogram.tsx
@@ -1,0 +1,36 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, radii, spacing } from '../theme';
+
+type Bucket = { label: string; count: number };
+
+export function LengthHistogram({ buckets }: { buckets: Bucket[] }) {
+  const max = Math.max(1, ...buckets.map((b) => b.count));
+  return (
+    <View style={styles.wrap}>
+      {buckets.map((b) => (
+        <View key={b.label} style={styles.row}>
+          <Text style={styles.label}>{b.label}</Text>
+          <View style={styles.barTrack}>
+            <View style={[styles.barFill, { width: `${(b.count / max) * 100}%` }]} />
+          </View>
+          <Text style={styles.count}>{b.count}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { gap: spacing.sm },
+  row: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
+  label: { color: colors.textMuted, width: 56, fontSize: 12 },
+  barTrack: {
+    flex: 1,
+    height: 18,
+    backgroundColor: colors.border,
+    borderRadius: radii.sm,
+    overflow: 'hidden',
+  },
+  barFill: { height: '100%', backgroundColor: colors.primary, borderRadius: radii.sm },
+  count: { color: colors.text, width: 24, textAlign: 'right', fontSize: 12 },
+});

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -402,7 +402,8 @@ export async function loadStatsBundle(): Promise<StatsBundle> {
   }
 
   const buckets = [
-    { label: '5–15m', minSec: 0, maxSec: 15 * 60, count: 0 },
+    { label: '<5m', minSec: 0, maxSec: 5 * 60, count: 0 },
+    { label: '5–15m', minSec: 5 * 60, maxSec: 15 * 60, count: 0 },
     { label: '15–30m', minSec: 15 * 60, maxSec: 30 * 60, count: 0 },
     { label: '30–45m', minSec: 30 * 60, maxSec: 45 * 60, count: 0 },
     { label: '45m+', minSec: 45 * 60, maxSec: Infinity, count: 0 },

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -98,6 +98,36 @@ export type HomeStats = {
   gracesAvailable: number;
 };
 
+export type DayKind = 'none' | 'started' | 'converted';
+
+export type ContributionDay = {
+  dateKey: string;
+  weekday: string;
+  kind: DayKind;
+  sessionCount: number;
+};
+
+export type TodayStats = {
+  startedToday: boolean;
+  totalFocusSeconds: number;
+  firstStartTimestamp: number | null;
+};
+
+export type AllTimeStats = {
+  totalSessions: number;
+  totalFocusSeconds: number;
+  averageSessionSeconds: number;
+  conversionRate: number;
+};
+
+export type StatsBundle = {
+  today: TodayStats;
+  contribution: ContributionDay[];
+  allTime: AllTimeStats;
+  hourCounts: number[];
+  lengthBuckets: { label: string; minSec: number; maxSec: number; count: number }[];
+};
+
 function toLocalDateKey(timestampMs: number): string {
   const d = new Date(timestampMs);
   const y = d.getFullYear();
@@ -286,5 +316,112 @@ export async function loadHomeStats(): Promise<HomeStats> {
     currentConversionStreak: currentConversion,
     bestConversionStreak: state.best_conversion,
     gracesAvailable: state.graces_available,
+  };
+}
+
+const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+function startOfLocalDay(timestampMs: number): number {
+  const d = new Date(timestampMs);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+export async function loadStatsBundle(): Promise<StatsBundle> {
+  const db = await getDb();
+  const now = Date.now();
+  const startToday = startOfLocalDay(now);
+  const endToday = startToday + 24 * 60 * 60 * 1000;
+  const start7Days = startToday - 6 * 24 * 60 * 60 * 1000;
+
+  const todayRows = await db.getAllAsync<SessionRow>(
+    'SELECT * FROM sessions WHERE started_at >= ? AND started_at < ? ORDER BY started_at ASC',
+    startToday,
+    endToday,
+  );
+  const today: TodayStats = {
+    startedToday: todayRows.length > 0,
+    totalFocusSeconds: todayRows.reduce((acc, r) => acc + r.duration_seconds, 0),
+    firstStartTimestamp: todayRows[0]?.started_at ?? null,
+  };
+
+  const weekRows = await db.getAllAsync<SessionRow>(
+    'SELECT * FROM sessions WHERE started_at >= ? AND started_at < ? ORDER BY started_at ASC',
+    start7Days,
+    endToday,
+  );
+  const byDay = new Map<string, { count: number; converted: boolean }>();
+  for (const r of weekRows) {
+    const key = toLocalDateKey(r.started_at);
+    const prev = byDay.get(key) ?? { count: 0, converted: false };
+    byDay.set(key, {
+      count: prev.count + 1,
+      converted: prev.converted || r.converted === 1,
+    });
+  }
+  const contribution: ContributionDay[] = [];
+  for (let i = 0; i < 7; i++) {
+    const dayMs = start7Days + i * 24 * 60 * 60 * 1000;
+    const key = toLocalDateKey(dayMs);
+    const entry = byDay.get(key);
+    const kind: DayKind = !entry ? 'none' : entry.converted ? 'converted' : 'started';
+    contribution.push({
+      dateKey: key,
+      weekday: WEEKDAY_LABELS[new Date(dayMs).getDay()],
+      kind,
+      sessionCount: entry?.count ?? 0,
+    });
+  }
+
+  const allTotals = await db.getFirstAsync<{
+    count: number;
+    total: number | null;
+    converted: number;
+  }>(
+    `SELECT COUNT(*) AS count,
+            SUM(duration_seconds) AS total,
+            SUM(converted) AS converted
+     FROM sessions`,
+  );
+  const totalSessions = allTotals?.count ?? 0;
+  const totalFocusSeconds = allTotals?.total ?? 0;
+  const allTime: AllTimeStats = {
+    totalSessions,
+    totalFocusSeconds,
+    averageSessionSeconds: totalSessions > 0 ? Math.round(totalFocusSeconds / totalSessions) : 0,
+    conversionRate: totalSessions > 0 ? (allTotals?.converted ?? 0) / totalSessions : 0,
+  };
+
+  const allRows = await db.getAllAsync<{ started_at: number; duration_seconds: number }>(
+    'SELECT started_at, duration_seconds FROM sessions',
+  );
+  const hourCounts = new Array(24).fill(0) as number[];
+  for (const r of allRows) {
+    const h = new Date(r.started_at).getHours();
+    hourCounts[h] += 1;
+  }
+
+  const buckets = [
+    { label: '5–15m', minSec: 0, maxSec: 15 * 60, count: 0 },
+    { label: '15–30m', minSec: 15 * 60, maxSec: 30 * 60, count: 0 },
+    { label: '30–45m', minSec: 30 * 60, maxSec: 45 * 60, count: 0 },
+    { label: '45m+', minSec: 45 * 60, maxSec: Infinity, count: 0 },
+  ];
+  for (const r of allRows) {
+    const s = r.duration_seconds;
+    for (const b of buckets) {
+      if (s >= b.minSec && s < b.maxSec) {
+        b.count += 1;
+        break;
+      }
+    }
+  }
+
+  return {
+    today,
+    contribution,
+    allTime,
+    hourCounts,
+    lengthBuckets: buckets,
   };
 }

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -2,4 +2,5 @@ export type RootStackParamList = {
   Home: undefined;
   Timer: { startedAt: number };
   SessionEnd: { startedAt: number; reachedFiveAt: number };
+  Stats: undefined;
 };

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -64,11 +64,18 @@ export default function HomeScreen({ navigation }: Props) {
           <Text style={styles.startSubtitle}>5 minutes</Text>
         </Pressable>
 
-        <View style={styles.statsRow}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="View stats"
+          onPress={() => navigation.navigate('Stats')}
+          style={({ pressed }) => [styles.statsRow, pressed && { opacity: 0.7 }]}
+        >
           <Stat label="Sessions" value={String(stats?.totalSessions ?? 0)} />
           <View style={styles.statDivider} />
           <Stat label="Total focus" value={formatFocusTime(stats?.totalFocusSeconds ?? 0)} />
-        </View>
+          <View style={styles.statDivider} />
+          <Text style={styles.statsLink}>Stats ›</Text>
+        </Pressable>
       </View>
     </SafeAreaView>
   );
@@ -168,4 +175,5 @@ const styles = StyleSheet.create({
     letterSpacing: 1,
   },
   statDivider: { width: 1, height: 28, backgroundColor: colors.border },
+  statsLink: { color: colors.primary, fontSize: 13, fontWeight: '500' },
 });

--- a/src/screens/StatsScreen.tsx
+++ b/src/screens/StatsScreen.tsx
@@ -1,6 +1,6 @@
 import { useFocusEffect } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { useCallback, useState } from 'react';
+import { useCallback, useState, type ReactNode } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ContributionGraph } from '../components/ContributionGraph';
@@ -35,21 +35,35 @@ export default function StatsScreen({ navigation }: Props) {
   return (
     <SafeAreaView style={styles.safe} edges={['top', 'bottom']}>
       <View style={styles.header}>
-        <Pressable onPress={() => navigation.goBack()} hitSlop={12}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
+          onPress={() => navigation.goBack()}
+          hitSlop={12}
+        >
           <Text style={styles.back}>‹ Back</Text>
         </Pressable>
         <Text style={styles.title}>Stats</Text>
         <View style={{ width: 50 }} />
       </View>
 
-      <View style={styles.tabs}>
-        {(['today', 'week', 'all'] as Tab[]).map((t) => (
-          <Pressable key={t} onPress={() => setTab(t)} style={styles.tab}>
-            <Text style={[styles.tabText, tab === t && styles.tabActive]}>
-              {t === 'today' ? 'Today' : t === 'week' ? 'This Week' : 'All Time'}
-            </Text>
-          </Pressable>
-        ))}
+      <View style={styles.tabs} accessibilityRole="tablist">
+        {(['today', 'week', 'all'] as Tab[]).map((t) => {
+          const label = t === 'today' ? 'Today' : t === 'week' ? 'This Week' : 'All Time';
+          const selected = tab === t;
+          return (
+            <Pressable
+              key={t}
+              onPress={() => setTab(t)}
+              style={styles.tab}
+              accessibilityRole="tab"
+              accessibilityLabel={label}
+              accessibilityState={{ selected }}
+            >
+              <Text style={[styles.tabText, selected && styles.tabActive]}>{label}</Text>
+            </Pressable>
+          );
+        })}
       </View>
 
       <ScrollView contentContainerStyle={styles.content}>
@@ -74,7 +88,7 @@ export default function StatsScreen({ navigation }: Props) {
   );
 }
 
-function Card({ title, children }: { title: string; children: React.ReactNode }) {
+function Card({ title, children }: { title: string; children: ReactNode }) {
   return (
     <View style={styles.card}>
       <Text style={styles.cardTitle}>{title}</Text>

--- a/src/screens/StatsScreen.tsx
+++ b/src/screens/StatsScreen.tsx
@@ -1,0 +1,217 @@
+import { useFocusEffect } from '@react-navigation/native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useCallback, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ContributionGraph } from '../components/ContributionGraph';
+import { HourBars } from '../components/HourBars';
+import { LengthHistogram } from '../components/LengthHistogram';
+import { loadStatsBundle, type StatsBundle } from '../db';
+import { RootStackParamList } from '../navigation/types';
+import { colors, radii, spacing } from '../theme';
+import { formatFocusTime } from '../utils/time';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Stats'>;
+type Tab = 'today' | 'week' | 'all';
+
+export default function StatsScreen({ navigation }: Props) {
+  const [tab, setTab] = useState<Tab>('today');
+  const [data, setData] = useState<StatsBundle | null>(null);
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false;
+      loadStatsBundle().then((d) => {
+        if (!cancelled) setData(d);
+      });
+      return () => {
+        cancelled = true;
+      };
+    }, []),
+  );
+
+  const empty = data && data.allTime.totalSessions === 0;
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'bottom']}>
+      <View style={styles.header}>
+        <Pressable onPress={() => navigation.goBack()} hitSlop={12}>
+          <Text style={styles.back}>‹ Back</Text>
+        </Pressable>
+        <Text style={styles.title}>Stats</Text>
+        <View style={{ width: 50 }} />
+      </View>
+
+      <View style={styles.tabs}>
+        {(['today', 'week', 'all'] as Tab[]).map((t) => (
+          <Pressable key={t} onPress={() => setTab(t)} style={styles.tab}>
+            <Text style={[styles.tabText, tab === t && styles.tabActive]}>
+              {t === 'today' ? 'Today' : t === 'week' ? 'This Week' : 'All Time'}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <ScrollView contentContainerStyle={styles.content}>
+        {!data ? (
+          <Text style={styles.emptyText}>Loading…</Text>
+        ) : empty ? (
+          <View style={styles.emptyWrap}>
+            <Text style={styles.emptyTitle}>No sessions yet</Text>
+            <Text style={styles.emptyText}>
+              Start a session to begin tracking your focus.
+            </Text>
+          </View>
+        ) : tab === 'today' ? (
+          <TodayView data={data} />
+        ) : tab === 'week' ? (
+          <WeekView data={data} />
+        ) : (
+          <AllTimeView data={data} />
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.cardTitle}>{title}</Text>
+      {children}
+    </View>
+  );
+}
+
+function StatRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.statRow}>
+      <Text style={styles.statLabel}>{label}</Text>
+      <Text style={styles.statValue}>{value}</Text>
+    </View>
+  );
+}
+
+function formatHourLabel(ts: number): string {
+  const d = new Date(ts);
+  const h = d.getHours();
+  const m = d.getMinutes();
+  const ampm = h < 12 ? 'AM' : 'PM';
+  const h12 = h % 12 === 0 ? 12 : h % 12;
+  return `${h12}:${String(m).padStart(2, '0')} ${ampm}`;
+}
+
+function TodayView({ data }: { data: StatsBundle }) {
+  const { today } = data;
+  return (
+    <Card title="Today">
+      <StatRow label="Started" value={today.startedToday ? 'Yes' : 'Not yet'} />
+      <StatRow label="Focus time" value={formatFocusTime(today.totalFocusSeconds)} />
+      <StatRow
+        label="First session"
+        value={today.firstStartTimestamp ? formatHourLabel(today.firstStartTimestamp) : '—'}
+      />
+    </Card>
+  );
+}
+
+function WeekView({ data }: { data: StatsBundle }) {
+  return (
+    <>
+      <Card title="Last 7 days">
+        <ContributionGraph days={data.contribution} />
+        <View style={styles.legend}>
+          <LegendDot color={colors.border} label="None" />
+          <LegendDot color="#3D5BCB" label="Started" />
+          <LegendDot color={colors.success} label="Converted" />
+        </View>
+      </Card>
+    </>
+  );
+}
+
+function AllTimeView({ data }: { data: StatsBundle }) {
+  const { allTime, hourCounts, lengthBuckets } = data;
+  const conversionPct = Math.round(allTime.conversionRate * 100);
+  return (
+    <>
+      <Card title="All time">
+        <StatRow label="Sessions" value={String(allTime.totalSessions)} />
+        <StatRow label="Total focus" value={formatFocusTime(allTime.totalFocusSeconds)} />
+        <StatRow label="Avg session" value={formatFocusTime(allTime.averageSessionSeconds)} />
+        <StatRow label="Conversion rate" value={`${conversionPct}%`} />
+      </Card>
+      <Card title="Best time of day">
+        <HourBars counts={hourCounts} />
+      </Card>
+      <Card title="Session length">
+        <LengthHistogram buckets={lengthBuckets} />
+      </Card>
+    </>
+  );
+}
+
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <View style={styles.legendItem}>
+      <View style={[styles.legendDot, { backgroundColor: color }]} />
+      <Text style={styles.legendLabel}>{label}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+  },
+  back: { color: colors.primary, fontSize: 16, width: 50 },
+  title: { color: colors.text, fontSize: 20, fontWeight: '600' },
+  tabs: {
+    flexDirection: 'row',
+    paddingHorizontal: spacing.lg,
+    gap: spacing.sm,
+    marginBottom: spacing.sm,
+  },
+  tab: {
+    flex: 1,
+    paddingVertical: spacing.sm,
+    alignItems: 'center',
+    borderBottomWidth: 2,
+    borderBottomColor: 'transparent',
+  },
+  tabText: { color: colors.textMuted, fontSize: 14, letterSpacing: 0.5 },
+  tabActive: { color: colors.text, fontWeight: '600' },
+  content: { padding: spacing.lg, gap: spacing.md, paddingBottom: spacing.xl },
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: radii.md,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  cardTitle: {
+    color: colors.textMuted,
+    fontSize: 11,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    marginBottom: spacing.xs,
+  },
+  statRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: spacing.xs,
+  },
+  statLabel: { color: colors.textMuted, fontSize: 14 },
+  statValue: { color: colors.text, fontSize: 16, fontWeight: '500' },
+  legend: { flexDirection: 'row', gap: spacing.md, marginTop: spacing.sm },
+  legendItem: { flexDirection: 'row', alignItems: 'center', gap: spacing.xs },
+  legendDot: { width: 10, height: 10, borderRadius: 2 },
+  legendLabel: { color: colors.textMuted, fontSize: 11 },
+  emptyWrap: { alignItems: 'center', paddingVertical: spacing.xl, gap: spacing.sm },
+  emptyTitle: { color: colors.text, fontSize: 18, fontWeight: '600' },
+  emptyText: { color: colors.textMuted, fontSize: 14, textAlign: 'center' },
+});


### PR DESCRIPTION
Closes #3.

## Summary
- New `Stats` screen with **Today / This Week / All Time** tabs reachable from Home (Home stats row is now tappable).
- **Today**: started yes/no, focus time, first-session timestamp.
- **This Week**: GitHub-style 7-day contribution graph color-coded None / Started / Converted, with a legend.
- **All Time**: total sessions, total focus, average session, conversion rate; **best time of day** (24-hour bar chart); **session length distribution** histogram (`<5m` / `5–15m` / `15–30m` / `30–45m` / `45m+` buckets).
- New aggregator `db.loadStatsBundle()` that returns today rows, last-7-days bucketed sessions, all-time totals, hour counts, and length buckets. (Multiple SQLite queries internally — no claim of single round trip.)
- Empty state for fresh installs.
- Accessibility: tabs use `accessibilityRole="tab"` + `accessibilityState.selected`; back button has role + label; contribution-graph cells are marked `accessible` so their labels are exposed.
- `app.json` + `package.json` versions bumped to **0.3.0**.

## Deviation from issue scope: charts
The stage 3 issue called out Victory Native as the chart library. I implemented the three charts with plain React Native views (`<View>` rectangles sized via flex / percent height) instead. Reasons:
- Victory Native v41 requires `@shopify/react-native-skia` + Reanimated 4 + Gesture Handler. Reanimated 4 needs the worklets babel plugin and isn't fully drop-in for SDK 54 + Expo Go without extra setup.
- The three charts we ship (7-cell heatmap, 24-bar hour chart, 5-row length histogram) are simple shapes — Skia/Reanimated buys nothing here.
- Result: ~250 KB less in the bundle, zero native module setup, immediately works in Expo Go.
- If we ever want animated/interactive charts (drill-down, tooltips), Victory Native swap is one component edit per chart.

## Test plan
- [ ] Tap stats row on Home → Stats screen opens
- [ ] Today tab shows current day's data
- [ ] This Week tab shows 7-day heatmap; today's column matches actual session state
- [ ] All Time tab shows totals and both charts; hour bars highlight your real focus hours
- [ ] Cancelled <5min session shows up in the `<5m` histogram bucket, not `5–15m`
- [ ] Fresh install (or after reset) shows empty state in all three tabs
- [ ] `npm run lint` and `npm run typecheck` pass