### PR TITLE
Stage 4 — Gamification

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Just 5",
     "slug": "just-5",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "just-5",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "index.ts",
   "scripts": {
     "start": "expo start",

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,4 +1,5 @@
 import * as SQLite from 'expo-sqlite';
+import { deriveFocusTitle, type FocusTitle, type MilestoneKey } from '../gamification';
 
 const DB_NAME = 'just5.db';
 const MAX_GRACES = 3;
@@ -25,6 +26,11 @@ export function getDb(): Promise<SQLite.SQLiteDatabase> {
         );
         INSERT OR IGNORE INTO streak_state (id, current_daily, last_started_date)
           VALUES (1, 0, NULL);
+        CREATE TABLE IF NOT EXISTS milestones (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          key TEXT NOT NULL UNIQUE,
+          achieved_at INTEGER NOT NULL
+        );
       `);
       await migrateStreakState(db);
       return db;
@@ -96,6 +102,7 @@ export type HomeStats = {
   currentConversionStreak: number;
   bestConversionStreak: number;
   gracesAvailable: number;
+  focusTitle: FocusTitle;
 };
 
 export type DayKind = 'none' | 'started' | 'converted';
@@ -120,12 +127,23 @@ export type AllTimeStats = {
   conversionRate: number;
 };
 
+export type PersonalRecords = {
+  longestSessionSeconds: number;
+  longestDailyStreak: number;
+  longestConversionStreak: number;
+  mostFocusInDaySeconds: number;
+  mostFocusInDayKey: string | null;
+};
+
 export type StatsBundle = {
   today: TodayStats;
   contribution: ContributionDay[];
   allTime: AllTimeStats;
   hourCounts: number[];
   lengthBuckets: { label: string; minSec: number; maxSec: number; count: number }[];
+  records: PersonalRecords;
+  focusTitle: FocusTitle;
+  unlockedMilestones: { key: MilestoneKey; achievedAt: number }[];
 };
 
 function toLocalDateKey(timestampMs: number): string {
@@ -239,13 +257,33 @@ function maybeEarnGrace(
   return { graces: gracesAvailable, earnedAt: gracesEarnedAtStreak };
 }
 
+async function readUnlockedMilestoneKeys(db: SQLite.SQLiteDatabase): Promise<Set<MilestoneKey>> {
+  const rows = await db.getAllAsync<{ key: MilestoneKey }>('SELECT key FROM milestones');
+  return new Set(rows.map((r) => r.key));
+}
+
+async function unlockMilestones(
+  db: SQLite.SQLiteDatabase,
+  keys: MilestoneKey[],
+  achievedAt: number,
+): Promise<void> {
+  for (const k of keys) {
+    await db.runAsync(
+      'INSERT OR IGNORE INTO milestones (key, achieved_at) VALUES (?, ?)',
+      k,
+      achievedAt,
+    );
+  }
+}
+
 export async function recordSession(params: {
   startedAt: number;
   endedAt: number;
   durationSeconds: number;
   converted: boolean;
-}): Promise<void> {
+}): Promise<{ newlyUnlocked: MilestoneKey[] }> {
   const db = await getDb();
+  let newlyUnlocked: MilestoneKey[] = [];
   await db.withTransactionAsync(async () => {
     await db.runAsync(
       'INSERT INTO sessions (started_at, ended_at, duration_seconds, converted) VALUES (?, ?, ?, ?)',
@@ -280,13 +318,40 @@ export async function recordSession(params: {
       grace.graces,
       grace.earnedAt,
     );
+
+    const totals = await db.getFirstAsync<{ count: number }>(
+      'SELECT COUNT(*) AS count FROM sessions',
+    );
+    const sessionCount = totals?.count ?? 0;
+    const already = await readUnlockedMilestoneKeys(db);
+    const candidates: MilestoneKey[] = [];
+    if (sessionCount >= 1 && !already.has('first_session')) candidates.push('first_session');
+    if (sessionCount >= 10 && !already.has('ten_sessions')) candidates.push('ten_sessions');
+    if (params.durationSeconds >= 60 * 60 && !already.has('first_60min_session')) {
+      candidates.push('first_60min_session');
+    }
+    if (daily.current >= 7 && !already.has('first_7_day_streak')) {
+      candidates.push('first_7_day_streak');
+    }
+    if (daily.current >= 30 && !already.has('first_30_day_streak')) {
+      candidates.push('first_30_day_streak');
+    }
+    if (candidates.length > 0) {
+      await unlockMilestones(db, candidates, params.endedAt);
+      newlyUnlocked = candidates;
+    }
   });
+  return { newlyUnlocked };
 }
 
 export async function loadHomeStats(): Promise<HomeStats> {
   const db = await getDb();
-  const totals = await db.getFirstAsync<{ count: number; total: number | null }>(
-    'SELECT COUNT(*) AS count, SUM(duration_seconds) AS total FROM sessions',
+  const totals = await db.getFirstAsync<{
+    count: number;
+    total: number | null;
+    converted: number;
+  }>(
+    'SELECT COUNT(*) AS count, SUM(duration_seconds) AS total, SUM(converted) AS converted FROM sessions',
   );
   const state = await readStreakState(db);
   const todayKey = toLocalDateKey(Date.now());
@@ -308,14 +373,21 @@ export async function loadHomeStats(): Promise<HomeStats> {
     if (diff > 1) currentConversion = 0;
   }
 
+  const totalSessions = totals?.count ?? 0;
+  const conversionRate = totalSessions > 0 ? (totals?.converted ?? 0) / totalSessions : 0;
+
   return {
-    totalSessions: totals?.count ?? 0,
+    totalSessions,
     totalFocusSeconds: totals?.total ?? 0,
     currentDailyStreak: currentDaily,
     bestDailyStreak: state.best_daily,
     currentConversionStreak: currentConversion,
     bestConversionStreak: state.best_conversion,
     gracesAvailable: state.graces_available,
+    focusTitle: deriveFocusTitle({
+      currentDailyStreak: currentDaily,
+      conversionRate,
+    }),
   };
 }
 
@@ -418,11 +490,48 @@ export async function loadStatsBundle(): Promise<StatsBundle> {
     }
   }
 
+  const state = await readStreakState(db);
+
+  let longestSessionSeconds = 0;
+  const focusByDay = new Map<string, number>();
+  for (const r of allRows) {
+    if (r.duration_seconds > longestSessionSeconds) longestSessionSeconds = r.duration_seconds;
+    const key = toLocalDateKey(r.started_at);
+    focusByDay.set(key, (focusByDay.get(key) ?? 0) + r.duration_seconds);
+  }
+  let mostFocusInDaySeconds = 0;
+  let mostFocusInDayKey: string | null = null;
+  for (const [key, total] of focusByDay) {
+    if (total > mostFocusInDaySeconds) {
+      mostFocusInDaySeconds = total;
+      mostFocusInDayKey = key;
+    }
+  }
+  const records: PersonalRecords = {
+    longestSessionSeconds,
+    longestDailyStreak: state.best_daily,
+    longestConversionStreak: state.best_conversion,
+    mostFocusInDaySeconds,
+    mostFocusInDayKey,
+  };
+
+  const focusTitle = deriveFocusTitle({
+    currentDailyStreak: state.current_daily,
+    conversionRate: allTime.conversionRate,
+  });
+
+  const milestoneRows = await db.getAllAsync<{ key: MilestoneKey; achieved_at: number }>(
+    'SELECT key, achieved_at FROM milestones ORDER BY achieved_at ASC',
+  );
+
   return {
     today,
     contribution,
     allTime,
     hourCounts,
     lengthBuckets: buckets,
+    records,
+    focusTitle,
+    unlockedMilestones: milestoneRows.map((m) => ({ key: m.key, achievedAt: m.achieved_at })),
   };
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -162,6 +162,20 @@ function dayDiffInDays(a: string, b: string): number {
   return Math.round((bMs - aMs) / (1000 * 60 * 60 * 24));
 }
 
+function effectiveCurrentDaily(state: StreakStateRow, todayKey: string): number {
+  if (!state.last_started_date || state.current_daily <= 0) return state.current_daily;
+  const diff = dayDiffInDays(state.last_started_date, todayKey);
+  if (diff <= 1) return state.current_daily;
+  const missed = diff - 1;
+  return state.graces_available >= missed ? state.current_daily : 0;
+}
+
+function effectiveCurrentConversion(state: StreakStateRow, todayKey: string): number {
+  if (!state.last_converted_date || state.current_conversion <= 0) return state.current_conversion;
+  const diff = dayDiffInDays(state.last_converted_date, todayKey);
+  return diff > 1 ? 0 : state.current_conversion;
+}
+
 async function readStreakState(db: SQLite.SQLiteDatabase): Promise<StreakStateRow> {
   const row = await db.getFirstAsync<StreakStateRow>(
     `SELECT current_daily, best_daily, last_started_date,
@@ -349,29 +363,15 @@ export async function loadHomeStats(): Promise<HomeStats> {
   const totals = await db.getFirstAsync<{
     count: number;
     total: number | null;
-    converted: number;
+    converted: number | null;
   }>(
     'SELECT COUNT(*) AS count, SUM(duration_seconds) AS total, SUM(converted) AS converted FROM sessions',
   );
   const state = await readStreakState(db);
   const todayKey = toLocalDateKey(Date.now());
 
-  let currentDaily = state.current_daily;
-  if (state.last_started_date && currentDaily > 0) {
-    const diff = dayDiffInDays(state.last_started_date, todayKey);
-    if (diff > 1) {
-      const missed = diff - 1;
-      if (state.graces_available < missed) {
-        currentDaily = 0;
-      }
-    }
-  }
-
-  let currentConversion = state.current_conversion;
-  if (state.last_converted_date && currentConversion > 0) {
-    const diff = dayDiffInDays(state.last_converted_date, todayKey);
-    if (diff > 1) currentConversion = 0;
-  }
+  const currentDaily = effectiveCurrentDaily(state, todayKey);
+  const currentConversion = effectiveCurrentConversion(state, todayKey);
 
   const totalSessions = totals?.count ?? 0;
   const conversionRate = totalSessions > 0 ? (totals?.converted ?? 0) / totalSessions : 0;
@@ -448,7 +448,7 @@ export async function loadStatsBundle(): Promise<StatsBundle> {
   const allTotals = await db.getFirstAsync<{
     count: number;
     total: number | null;
-    converted: number;
+    converted: number | null;
   }>(
     `SELECT COUNT(*) AS count,
             SUM(duration_seconds) AS total,
@@ -467,12 +467,8 @@ export async function loadStatsBundle(): Promise<StatsBundle> {
   const allRows = await db.getAllAsync<{ started_at: number; duration_seconds: number }>(
     'SELECT started_at, duration_seconds FROM sessions',
   );
-  const hourCounts = new Array(24).fill(0) as number[];
-  for (const r of allRows) {
-    const h = new Date(r.started_at).getHours();
-    hourCounts[h] += 1;
-  }
 
+  const hourCounts = new Array(24).fill(0) as number[];
   const buckets = [
     { label: '<5m', minSec: 0, maxSec: 5 * 60, count: 0 },
     { label: '5–15m', minSec: 5 * 60, maxSec: 15 * 60, count: 0 },
@@ -480,7 +476,11 @@ export async function loadStatsBundle(): Promise<StatsBundle> {
     { label: '30–45m', minSec: 30 * 60, maxSec: 45 * 60, count: 0 },
     { label: '45m+', minSec: 45 * 60, maxSec: Infinity, count: 0 },
   ];
+  let longestSessionSeconds = 0;
+  const focusByDay = new Map<string, number>();
+
   for (const r of allRows) {
+    hourCounts[new Date(r.started_at).getHours()] += 1;
     const s = r.duration_seconds;
     for (const b of buckets) {
       if (s >= b.minSec && s < b.maxSec) {
@@ -488,17 +488,11 @@ export async function loadStatsBundle(): Promise<StatsBundle> {
         break;
       }
     }
+    if (s > longestSessionSeconds) longestSessionSeconds = s;
+    const dayKey = toLocalDateKey(r.started_at);
+    focusByDay.set(dayKey, (focusByDay.get(dayKey) ?? 0) + s);
   }
 
-  const state = await readStreakState(db);
-
-  let longestSessionSeconds = 0;
-  const focusByDay = new Map<string, number>();
-  for (const r of allRows) {
-    if (r.duration_seconds > longestSessionSeconds) longestSessionSeconds = r.duration_seconds;
-    const key = toLocalDateKey(r.started_at);
-    focusByDay.set(key, (focusByDay.get(key) ?? 0) + r.duration_seconds);
-  }
   let mostFocusInDaySeconds = 0;
   let mostFocusInDayKey: string | null = null;
   for (const [key, total] of focusByDay) {
@@ -507,6 +501,10 @@ export async function loadStatsBundle(): Promise<StatsBundle> {
       mostFocusInDayKey = key;
     }
   }
+
+  const state = await readStreakState(db);
+  const todayKey = toLocalDateKey(now);
+
   const records: PersonalRecords = {
     longestSessionSeconds,
     longestDailyStreak: state.best_daily,
@@ -516,7 +514,7 @@ export async function loadStatsBundle(): Promise<StatsBundle> {
   };
 
   const focusTitle = deriveFocusTitle({
-    currentDailyStreak: state.current_daily,
+    currentDailyStreak: effectiveCurrentDaily(state, todayKey),
     conversionRate: allTime.conversionRate,
   });
 

--- a/src/gamification.ts
+++ b/src/gamification.ts
@@ -1,0 +1,25 @@
+export type FocusTitle = 'Warming Up' | 'In The Zone' | 'Flow State';
+
+export type MilestoneKey =
+  | 'first_session'
+  | 'ten_sessions'
+  | 'first_60min_session'
+  | 'first_7_day_streak'
+  | 'first_30_day_streak';
+
+export const MILESTONE_LABELS: Record<MilestoneKey, string> = {
+  first_session: 'First session',
+  ten_sessions: '10 sessions',
+  first_60min_session: '60+ minute session',
+  first_7_day_streak: '7-day streak',
+  first_30_day_streak: '30-day streak',
+};
+
+export function deriveFocusTitle(input: {
+  currentDailyStreak: number;
+  conversionRate: number;
+}): FocusTitle {
+  if (input.currentDailyStreak >= 30 && input.conversionRate >= 0.7) return 'Flow State';
+  if (input.currentDailyStreak >= 7) return 'In The Zone';
+  return 'Warming Up';
+}

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,5 +1,7 @@
+import type { MilestoneKey } from '../gamification';
+
 export type RootStackParamList = {
-  Home: undefined;
+  Home: { unlockedMilestones?: MilestoneKey[] } | undefined;
   Timer: { startedAt: number };
   SessionEnd: { startedAt: number; reachedFiveAt: number };
   Stats: undefined;

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,17 +1,21 @@
 import { useFocusEffect } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { loadHomeStats, type HomeStats } from '../db';
+import { MILESTONE_LABELS, type MilestoneKey } from '../gamification';
 import { RootStackParamList } from '../navigation/types';
 import { colors, radii, spacing } from '../theme';
 import { formatFocusTime } from '../utils/time';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
-export default function HomeScreen({ navigation }: Props) {
+const TOAST_DURATION_MS = 4000;
+
+export default function HomeScreen({ navigation, route }: Props) {
   const [stats, setStats] = useState<HomeStats | null>(null);
+  const [toast, setToast] = useState<MilestoneKey[] | null>(null);
 
   useFocusEffect(
     useCallback(() => {
@@ -24,6 +28,17 @@ export default function HomeScreen({ navigation }: Props) {
       };
     }, []),
   );
+
+  useEffect(() => {
+    const unlocked = route.params?.unlockedMilestones;
+    if (unlocked && unlocked.length > 0) {
+      setToast(unlocked);
+      navigation.setParams({ unlockedMilestones: undefined });
+      const t = setTimeout(() => setToast(null), TOAST_DURATION_MS);
+      return () => clearTimeout(t);
+    }
+    return undefined;
+  }, [route.params?.unlockedMilestones, navigation]);
 
   const onStart = () => {
     navigation.navigate('Timer', { startedAt: Date.now() });
@@ -46,13 +61,16 @@ export default function HomeScreen({ navigation }: Props) {
           />
         </View>
 
-        {(stats?.gracesAvailable ?? 0) > 0 && (
-          <View style={styles.gracesBadge}>
-            <Text style={styles.gracesText}>
-              {stats?.gracesAvailable} grace{stats?.gracesAvailable === 1 ? '' : 's'} saved
-            </Text>
-          </View>
-        )}
+        <View style={styles.titleRow}>
+          <Text style={styles.titleText}>{stats?.focusTitle ?? 'Warming Up'}</Text>
+          {(stats?.gracesAvailable ?? 0) > 0 && (
+            <View style={styles.gracesBadge}>
+              <Text style={styles.gracesText}>
+                {stats?.gracesAvailable} grace{stats?.gracesAvailable === 1 ? '' : 's'}
+              </Text>
+            </View>
+          )}
+        </View>
 
         <Pressable
           accessibilityRole="button"
@@ -76,6 +94,17 @@ export default function HomeScreen({ navigation }: Props) {
           <View style={styles.statDivider} />
           <Text style={styles.statsLink}>Stats ›</Text>
         </Pressable>
+
+        {toast && (
+          <View style={styles.toast} accessibilityLiveRegion="polite">
+            <Text style={styles.toastTitle}>Milestone unlocked</Text>
+            {toast.map((k) => (
+              <Text key={k} style={styles.toastBody}>
+                • {MILESTONE_LABELS[k]}
+              </Text>
+            ))}
+          </View>
+        )}
       </View>
     </SafeAreaView>
   );
@@ -135,17 +164,29 @@ const styles = StyleSheet.create({
   },
   streakValue: { color: colors.text, fontSize: 40, fontWeight: '700' },
   streakBest: { color: colors.textMuted, fontSize: 12 },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+  },
+  titleText: {
+    color: colors.text,
+    fontSize: 14,
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+    fontWeight: '600',
+  },
   gracesBadge: {
-    alignSelf: 'center',
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
     borderRadius: radii.pill,
     backgroundColor: colors.surface,
     borderWidth: 1,
     borderColor: colors.border,
-    marginTop: spacing.sm,
   },
-  gracesText: { color: colors.success, fontSize: 12, letterSpacing: 0.5 },
+  gracesText: { color: colors.success, fontSize: 11, letterSpacing: 0.5 },
   startButton: {
     alignSelf: 'center',
     width: 260,
@@ -176,4 +217,24 @@ const styles = StyleSheet.create({
   },
   statDivider: { width: 1, height: 28, backgroundColor: colors.border },
   statsLink: { color: colors.primary, fontSize: 13, fontWeight: '500' },
+  toast: {
+    position: 'absolute',
+    left: spacing.lg,
+    right: spacing.lg,
+    bottom: spacing.lg,
+    backgroundColor: colors.surface,
+    borderColor: colors.success,
+    borderWidth: 1,
+    borderRadius: radii.md,
+    padding: spacing.md,
+    gap: spacing.xs,
+  },
+  toastTitle: {
+    color: colors.success,
+    fontSize: 11,
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+    fontWeight: '600',
+  },
+  toastBody: { color: colors.text, fontSize: 14 },
 });

--- a/src/screens/SessionEndScreen.tsx
+++ b/src/screens/SessionEndScreen.tsx
@@ -38,13 +38,16 @@ export default function SessionEndScreen({ navigation, route }: Props) {
     savedRef.current = true;
     const endedAt = Date.now();
     const dur = Math.max(1, Math.floor((endedAt - startedAt) / 1000));
-    await recordSession({
+    const result = await recordSession({
       startedAt,
       endedAt,
       durationSeconds: dur,
       converted,
     });
-    navigation.popToTop();
+    navigation.navigate(
+      'Home',
+      result.newlyUnlocked.length ? { unlockedMilestones: result.newlyUnlocked } : undefined,
+    );
   };
 
   return (

--- a/src/screens/StatsScreen.tsx
+++ b/src/screens/StatsScreen.tsx
@@ -166,13 +166,7 @@ function formatDateMs(ms: number): string {
 function AllTimeView({ data }: { data: StatsBundle }) {
   const { allTime, hourCounts, lengthBuckets, records, focusTitle, unlockedMilestones } = data;
   const conversionPct = Math.round(allTime.conversionRate * 100);
-  const allMilestoneKeys: MilestoneKey[] = [
-    'first_session',
-    'ten_sessions',
-    'first_60min_session',
-    'first_7_day_streak',
-    'first_30_day_streak',
-  ];
+  const allMilestoneKeys = Object.keys(MILESTONE_LABELS) as MilestoneKey[];
   const achievedMap = new Map(unlockedMilestones.map((m) => [m.key, m.achievedAt]));
   return (
     <>

--- a/src/screens/StatsScreen.tsx
+++ b/src/screens/StatsScreen.tsx
@@ -7,6 +7,7 @@ import { ContributionGraph } from '../components/ContributionGraph';
 import { HourBars } from '../components/HourBars';
 import { LengthHistogram } from '../components/LengthHistogram';
 import { loadStatsBundle, type StatsBundle } from '../db';
+import { MILESTONE_LABELS, type MilestoneKey } from '../gamification';
 import { RootStackParamList } from '../navigation/types';
 import { colors, radii, spacing } from '../theme';
 import { formatFocusTime } from '../utils/time';
@@ -144,9 +145,35 @@ function WeekView({ data }: { data: StatsBundle }) {
   );
 }
 
+function formatDateKey(key: string | null): string {
+  if (!key) return '—';
+  const [y, m, d] = key.split('-').map(Number);
+  return new Date(y, m - 1, d).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatDateMs(ms: number): string {
+  return new Date(ms).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
 function AllTimeView({ data }: { data: StatsBundle }) {
-  const { allTime, hourCounts, lengthBuckets } = data;
+  const { allTime, hourCounts, lengthBuckets, records, focusTitle, unlockedMilestones } = data;
   const conversionPct = Math.round(allTime.conversionRate * 100);
+  const allMilestoneKeys: MilestoneKey[] = [
+    'first_session',
+    'ten_sessions',
+    'first_60min_session',
+    'first_7_day_streak',
+    'first_30_day_streak',
+  ];
+  const achievedMap = new Map(unlockedMilestones.map((m) => [m.key, m.achievedAt]));
   return (
     <>
       <Card title="All time">
@@ -154,6 +181,40 @@ function AllTimeView({ data }: { data: StatsBundle }) {
         <StatRow label="Total focus" value={formatFocusTime(allTime.totalFocusSeconds)} />
         <StatRow label="Avg session" value={formatFocusTime(allTime.averageSessionSeconds)} />
         <StatRow label="Conversion rate" value={`${conversionPct}%`} />
+        <StatRow label="Title" value={focusTitle} />
+      </Card>
+      <Card title="Personal records">
+        <StatRow
+          label="Longest session"
+          value={formatFocusTime(records.longestSessionSeconds)}
+        />
+        <StatRow label="Longest daily streak" value={`${records.longestDailyStreak} days`} />
+        <StatRow
+          label="Longest conversion"
+          value={`${records.longestConversionStreak} days`}
+        />
+        <StatRow
+          label="Most focus in a day"
+          value={
+            records.mostFocusInDaySeconds > 0
+              ? `${formatFocusTime(records.mostFocusInDaySeconds)} (${formatDateKey(records.mostFocusInDayKey)})`
+              : '—'
+          }
+        />
+      </Card>
+      <Card title="Milestones">
+        {allMilestoneKeys.map((k) => {
+          const achievedAt = achievedMap.get(k);
+          return (
+            <View key={k} style={styles.milestoneRow}>
+              <View style={[styles.milestoneDot, achievedAt ? styles.milestoneDotOn : null]} />
+              <Text style={[styles.milestoneLabel, !achievedAt && styles.milestoneLabelLocked]}>
+                {MILESTONE_LABELS[k]}
+              </Text>
+              {achievedAt && <Text style={styles.milestoneDate}>{formatDateMs(achievedAt)}</Text>}
+            </View>
+          );
+        })}
       </Card>
       <Card title="Best time of day">
         <HourBars counts={hourCounts} />
@@ -228,4 +289,20 @@ const styles = StyleSheet.create({
   emptyWrap: { alignItems: 'center', paddingVertical: spacing.xl, gap: spacing.sm },
   emptyTitle: { color: colors.text, fontSize: 18, fontWeight: '600' },
   emptyText: { color: colors.textMuted, fontSize: 14, textAlign: 'center' },
+  milestoneRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingVertical: spacing.xs,
+  },
+  milestoneDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: colors.border,
+  },
+  milestoneDotOn: { backgroundColor: colors.success },
+  milestoneLabel: { color: colors.text, fontSize: 14, flex: 1 },
+  milestoneLabelLocked: { color: colors.textMuted },
+  milestoneDate: { color: colors.textMuted, fontSize: 11 },
 });

--- a/src/screens/TimerScreen.tsx
+++ b/src/screens/TimerScreen.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Alert, BackHandler, Pressable, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { recordSession } from '../db';
+import type { MilestoneKey } from '../gamification';
 import { RootStackParamList } from '../navigation/types';
 import { colors, radii, spacing } from '../theme';
 import { FIVE_MINUTES_SECONDS, formatDuration } from '../utils/time';
@@ -42,15 +43,17 @@ export default function TimerScreen({ navigation, route }: Props) {
           onPress: async () => {
             const endedAt = Date.now();
             const dur = Math.floor((endedAt - startedAt) / 1000);
+            let unlocked: MilestoneKey[] = [];
             if (dur >= 60) {
-              await recordSession({
+              const result = await recordSession({
                 startedAt,
                 endedAt,
                 durationSeconds: dur,
                 converted: false,
               });
+              unlocked = result.newlyUnlocked;
             }
-            navigation.popToTop();
+            navigation.navigate('Home', unlocked.length ? { unlockedMilestones: unlocked } : undefined);
           },
         },
       ],


### PR DESCRIPTION
Closes #4.

## Summary
Three light gamification layers on top of v0.3.0.

### Focus titles
- `Warming Up` (default)
- `In The Zone` — ≥7-day daily streak
- `Flow State` — ≥30-day daily streak **and** ≥70% conversion rate

Derived in pure `deriveFocusTitle()` (src/gamification.ts), surfaced via `HomeStats.focusTitle`. Shown subtly on Home between the streak header and the Start button. Also appears in the Stats All-time card.

### Milestones
New `milestones` table with `(key UNIQUE, achieved_at)`. Five milestones evaluated inside the `recordSession` transaction so they can never desync:
- First session
- 10 sessions
- First 60+ minute session
- First 7-day streak
- First 30-day streak

`recordSession` now returns `{ newlyUnlocked: MilestoneKey[] }`. Both TimerScreen (cancel) and SessionEndScreen (finish) forward the unlocked keys to Home via route params. Home renders a small bottom toast for 4 seconds, then clears its own params. Stats All-time has a Milestones card showing all five with unlocked/locked dots and unlock dates.

### Personal Records
New Personal Records card on Stats All-time:
- Longest single session
- Longest daily streak (from existing `best_daily`)
- Longest conversion streak (from existing `best_conversion`)
- Most focus in a single day (computed from session rows)

### Other
- `loadStatsBundle` extended with `records`, `focusTitle`, `unlockedMilestones`.
- `loadHomeStats` adds the `focusTitle` field (and reads `SUM(converted)` to compute the rate).
- Versions bumped to 0.4.0.

## Test plan
- [ ] Fresh install → first save unlocks `first_session` toast on Home
- [ ] After 10 saves → `ten_sessions` toast appears once and never again
- [ ] Long session (≥60 min) on Keep going → `first_60min_session` unlocks
- [ ] Day 7 of daily streak → `first_7_day_streak` unlocks
- [ ] Title updates correctly across thresholds (default → In The Zone → Flow State)
- [ ] Stats → All time → Personal Records and Milestones cards render
- [ ] Toast auto-dismisses after ~4s
- [ ] Cancel <60s session does NOT trigger any milestone (no recordSession call)